### PR TITLE
Retfix

### DIFF
--- a/dodfminer/extract/polished/acts/aposentadoria.py
+++ b/dodfminer/extract/polished/acts/aposentadoria.py
@@ -66,11 +66,6 @@ class RetAposentadoria(Atos):
     def _regex_flags(self):
         return re.IGNORECASE
 
-    def _load_model(self):
-        f_path = os.path.dirname(__file__)
-        f_path += '/models/efetivos_ret.pkl'
-        return joblib.load(f_path)
-
     def _act_name(self):
         return "Retificações de Aposentadoria"
 

--- a/dodfminer/extract/polished/backend/ner.py
+++ b/dodfminer/extract/polished/backend/ner.py
@@ -44,7 +44,7 @@ class ActNER:
         """
         # pylint: disable=access-member-before-definition
         if self._backend == 'ner':
-            print(f"Act {self._name} does not have a model: FALLING BACK TO REGEX")
+            print(f"Act {self._name} does not have an entity extraction model: FALLING BACK TO REGEX")
             self._backend = 'regex'
         else:
             self._backend = 'regex'

--- a/dodfminer/extract/polished/backend/ner.py
+++ b/dodfminer/extract/polished/backend/ner.py
@@ -86,8 +86,6 @@ class ActNER:
         symbols = ['(', ',', '.', '/', '-']
         all = letters + numbers + symbols + [' ']
 
-        print(sentence)
-
         lim = []
         if sentence[0] != ' ':
             lim.append(0)

--- a/dodfminer/extract/polished/backend/seg.py
+++ b/dodfminer/extract/polished/backend/seg.py
@@ -214,7 +214,6 @@ class ActSeg:
             List of acts in the text.
         """
 
-        print(prediction)
         acts = []
         limits = self._limits(text)
 

--- a/dodfminer/extract/polished/backend/seg.py
+++ b/dodfminer/extract/polished/backend/seg.py
@@ -36,7 +36,7 @@ class ActSeg:
             if self._seg_model is not None:
                 return self._crf_instances
             else:
-                print(f"Act {self._name} does not have a segmentation model: Using regex for segmentation")
+                print(f"Act {self._name} does not have a segmentation model: FALLING BACK TO REGEX")
                 return self._regex_instances
         else:
             self._backend = 'regex'

--- a/tests/test_extract_polished_acts.py
+++ b/tests/test_extract_polished_acts.py
@@ -233,7 +233,7 @@ def test_act_retretirement_consistence_rule(act_retapos):
 
 def test_act_retretirement_ner():
     act = RetAposentadoria(file, 'ner')
-    assert isinstance(act._load_model(), sklearn_crfsuite.estimator.CRF)
+    assert act._backend == 'regex'
 
 #
 #

--- a/tests/test_extract_polished_backend_ner.py
+++ b/tests/test_extract_polished_backend_ner.py
@@ -196,6 +196,6 @@ def test_act_ner_predictions_dict(act_ner_with_model):
         'Processo GDF/SEI': np.nan,
         'orgao': np.nan
     }
-    print(act_ner_with_model._predictions_dict(sentence, prediction))
+
     assert entidades == act_ner_with_model._predictions_dict(
         sentence, prediction)

--- a/tests/test_extract_polished_backend_seg.py
+++ b/tests/test_extract_polished_backend_seg.py
@@ -95,7 +95,6 @@ def test_act_seg_crf_instances(act_seg_ner):
         "00133-00002735/2020-97."
     act_seg_ner._acts_str = []
     act = act_seg_ner._seg_function()
-    print(act)
 
     assert len(act) == 2
 


### PR DESCRIPTION
- Modelo de extração de entidades para retificação de aposentadoria retirado (modelo não existe)
- Retirados prints desnecessários
- Pequenas modificações em outros prints