### PR TITLE
Normalize text in json personal acts

### DIFF
--- a/dodfminer/__version__.py
+++ b/dodfminer/__version__.py
@@ -1,4 +1,4 @@
-version_info = (1, 4, 5)
+version_info = (1, 4, 6)
 # format:
 # ('dodf_major', 'dodf_minor', 'dodf_patch')
 

--- a/dodfminer/extract/polished/acts/base.py
+++ b/dodfminer/extract/polished/acts/base.py
@@ -6,6 +6,7 @@ extract information from a specialized act.
 
 import re
 import json
+import unicodedata
 import pandas as pd
 
 from dodfminer.extract.polished.backend.regex import ActRegex
@@ -204,9 +205,8 @@ class Atos(ActRegex, ActNER, ActSeg):  # pylint: disable=too-many-instance-attri
             return
         self._data_frame = []
         for IOB, text in zip(self._preds, self._acts_str):
-            ent_dict = {
-                'text': '',
-            } 
+            ent_dict = dict()
+            ent_dict['titulo'] = None
             ent_dict['text'] = ""
 
             text_split = self._split_sentence(text) + ["O"]
@@ -295,6 +295,8 @@ class Atos(ActRegex, ActNER, ActSeg):  # pylint: disable=too-many-instance-attri
                     txt = re.sub('<[^<]+?>', ' ', txt).replace('&nbsp', ' ')
                     all_txt.append(txt)
         self._text = ''.join(all_txt)
+        self._text = unicodedata.normalize('NFKD', self._text).encode(
+            'ascii', 'ignore').decode('utf8')
 
     def read_txt(self, file_name):
         """Reads a .txt file of a DODF.

--- a/dodfminer/extract/polished/acts/base_contratos.py
+++ b/dodfminer/extract/polished/acts/base_contratos.py
@@ -124,13 +124,9 @@ class AtosContrato:
     if len(self.atos_encontrados) == 0:
       return
     self.data_frame = []
-    for IOB, text, numdodf, titulo in zip(self.predicted, self.atos_encontrados['texto'], self.atos_encontrados['numero_dodf'], self.atos_encontrados['titulo']):
-      ent_dict = {
-        'numero_dodf': '',
-        'titulo': '',
-        'text': '',
-      } 
-      ent_dict['numero_dodf'] = numdodf
+    for IOB, text, _, titulo in zip(self.predicted, self.atos_encontrados['texto'], self.atos_encontrados['numero_dodf'], self.atos_encontrados['titulo']):
+      ent_dict = dict() 
+      # ent_dict['numero_dodf'] = numdodf
       ent_dict['titulo'] = titulo
       ent_dict['text'] = ""
 


### PR DESCRIPTION
- Normaliza texto (retira acentuações) para atos de pessoal em JSON
- Padroniza output das funções de highlight entre atos de pessoal e atos de contrato
- Altera versão do pacote para 1.4.6